### PR TITLE
Support for reading movies with frame headers

### DIFF
--- a/isx/__init__.py
+++ b/isx/__init__.py
@@ -195,7 +195,9 @@ class Movie:
         header_offset = 0
         footer_offset = 0
         if self.footer["hasFrameHeaderFooter"]:
-            header_offset = (index + 1) * bytes_per_pixel * 1280 * 2
+            header_footer_size_in_bytes = 1280 * 2 * 2 # The size of the frame header in bytes. The same for the footer.
+            header_offset = (index + 1) * header_footer_size_in_bytes
+            footer_offset = (index + 1) * header_footer_size_in_bytes            
 
             footer_offset = index * bytes_per_pixel * 1280 * 2
 

--- a/tests/test_isx.py
+++ b/tests/test_isx.py
@@ -9,6 +9,24 @@ from data import download
 # information about each movie that we will check
 movie_info = [
     dict(
+        name="multiplane_movie.isxd",
+        dtype=np.uint16,
+        num_pixels=(100, 160),
+        num_samples=30,
+        frame_max=3678,
+        frame_min=573,
+        frame_sum=38607353,
+    ),
+    dict(
+        name="dual_color_movie_with_dropped_frames.isxd",
+        dtype=np.uint16,
+        num_pixels=(288, 480),
+        num_samples=25,
+        frame_max=4091,
+        frame_min=828,
+        frame_sum=264539918,
+    ),
+    dict(
         name="movie_128x128x100_part1.isxd",
         dtype=np.float32,
         num_pixels=(128, 128),


### PR DESCRIPTION
# what

this PR supports reading movies with frame headers, which means that it can now read multi-plane and multi-color movies

## technical discussion

the goal of this repo has always been to act and behave like the IDPS API as much as possible. with the IDPS API, you can read multi-color or -plane movies directly. the way these movies are organized is that frames from subsequent channels/planes are simply stored one after the other, and you can simply read them like a normal movie. of course, this is not very useful, because you're mixing up channels/planes. 

the IDPS  API provides a deinterleave function, which is not part of this PR. the goal of this PR is to simply match what the IDPS API does with multi-color or mulit-plane movies

## checklist

- [x] read multi-plane movies
- [x] read multi-color movies
- [ ] documentation updates 

## testing

- [x] added test for multi-plane movie
- [x] added test for multi-color movie