### PR TITLE
chore: fix unit tests for python 3.13, pin pandas < 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ else ifeq ($(DETECTED_OS), linux)
 	CMAKE_OPTIONS += -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
 else ifeq ($(DETECTED_OS), mac)
 	CMAKE_GENERATOR = Xcode
+	CMAKE_OPTIONS += -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY='' -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=''
 endif
 
 check_os:
@@ -146,7 +147,7 @@ else ifeq ($(DETECTED_OS), linux)
 	make -j2
 else ifeq ($(DETECTED_OS), mac)
 	cd $(BUILD_PATH) && \
-	xcodebuild -alltargets -configuration $(BUILD_TYPE) -project isx.xcodeproj CODE_SIGN_IDENTITY=""
+	xcodebuild -alltargets -configuration $(BUILD_TYPE) -project isx.xcodeproj
 endif
 	$(VENV_ACTIVATE) && \
 	cd $(BUILD_PATH_BIN) && \

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -36,7 +36,7 @@ def run_all(os, deploy = false) {
         run_command("make setup REMOTE_DIR=${IDPS_REMOTE_EXT_DIR} REMOTE_LOCAL_DIR=${IDPS_REMOTE_EXT_COPY_DIR}", os)
     }
 
-    python_versions = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    python_versions = ["3.10", "3.11", "3.12", "3.13"]
     python_versions.each() {
         stage("Python ${it}") {
             run(os, it, deploy)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'numpy>=1.14',
         'scipy>=1.0',
         'tifffile>=0.15.1',
-        'pandas>=0.20.1',
+        'pandas>=0.20.1,<3',
         'pillow>=8.0.1',
         'openpyxl>=3.0.10', # Required for pandas Excel support
     ],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fix unit tests for python 3.13 by pinning pandas version < 3.

Additionally, stop testing on python 3.9, since this version stopped working on the windows server, and we are planning to deprecate support for this version since it's reached EOL.

## Testing Instructions

```
make clean
make env PYTHON=python3.13
THIRD_PARTY_DIR=$(pwd)/../mosaic2/third_party make build
THIRD_PARTY_DIR=$(pwd)/../mosaic2/third_party TEST_DATA_DIR=$(pwd)/../mosaic2/test_data make test
```

Alternatively, if you can't build the wheel file, here's one already built: https://bruker-my.sharepoint.com/:u:/p/nosheen_adil/IQDMEm5gCl-vSbCjZhv6q6NAAWDD2Ptt_yZnaq7wVbuh-E4?email=Brandon.Cazander%40bruker.com&e=UyeCCM

```
python3.13 -m venv venv
source venv/bin/activate
pip install isx-2.1.0-cp313-cp313-manylinux_2_34_x86_64.whl
python -c "import isx"
```

## Added/updated tests?
<!-- We encourage you to write unit tests when possible. -->

- [ ] Yes
- [x] No, and this is why: Only need to validate existing behavior.
- [ ] I need help with writing tests
